### PR TITLE
Add simple HTTP/2 server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Rust related
+/target/
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 # Rust related
 /target/
 
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 actix-web = "4"
 env_logger = "0.11.8"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "chattopia-api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+actix-web = "4"
+env_logger = "0.11.8"

--- a/src/health.rs
+++ b/src/health.rs
@@ -8,3 +8,4 @@ async fn health_check() -> HttpResponse {
 pub fn routes() -> Scope {
     web::scope("/health").service(health_check)
 }
+

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,10 @@
+use actix_web::{get, HttpResponse, Scope, web};
+
+#[get("")]
+async fn health_check() -> HttpResponse {
+    HttpResponse::Ok().body("OK")
+}
+
+pub fn routes() -> Scope {
+    web::scope("/health").service(health_check)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,3 +15,4 @@ async fn main() -> std::io::Result<()> {
         .run()
         .await
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,17 @@
+use actix_web::{App, HttpServer};
+
+mod health;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    HttpServer::new(|| {
+        App::new()
+            .service(health::routes())
+    })
+        .bind_auto_h2c(("127.0.0.1", 8000))?
+        .workers(8)
+        .run()
+        .await
+}


### PR DESCRIPTION
 - Added a simple Actix-web h2c server implementation.
 - Configured a `/health` endpoint. No logic implemented, it just returns 200 OK.
 - Added .gitignore to ignore Rust /target directory.

Issue: #3