### PR TITLE
Fix service address binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2024"
 [dependencies]
 actix-web = "4"
 env_logger = "0.11.8"
+log = "0.4.27"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,34 @@
 use actix_web::{App, HttpServer};
 
+use std::io::ErrorKind;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
 mod health;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    const PORT: u16 = 8000;
+
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
-    HttpServer::new(|| {
+    let app_factory = || {
         App::new()
             .service(health::routes())
-    })
-        .bind_auto_h2c(("127.0.0.1", 8000))?
-        .workers(8)
-        .run()
-        .await
+    };
+    
+    // Attempt to bind to IPv6, fallback to IPv4 on AddrNotAvailable
+    let addr_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), PORT);
+    let server = match HttpServer::new(app_factory).bind_auto_h2c(addr_v6) {
+        Ok(srv) => srv,
+        Err(err) if err.kind() == ErrorKind::AddrNotAvailable => {
+            eprintln!("IPv6 not available, falling back to IPv4");
+
+            let addr_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), PORT);
+            HttpServer::new(app_factory).bind_auto_h2c(addr_v4)?
+        }
+        Err(err) => return Err(err),
+    };
+
+    server.workers(8).run().await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use actix_web::{App, HttpServer};
 
+use log::warn;
+
 use std::io::ErrorKind;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
@@ -23,7 +25,7 @@ async fn main() -> std::io::Result<()> {
         Ok(srv) => srv,
         Err(err) if err.kind() == ErrorKind::AddrNotAvailable
             || err.raw_os_error() == Some(EAFNOSUPPORT) => {
-            eprintln!("IPv6 not available, falling back to IPv4");
+            warn!("IPv6 not available, falling back to IPv4");
 
             let addr_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), PORT);
             HttpServer::new(app_factory).bind_auto_h2c(addr_v4)?


### PR DESCRIPTION
 - Initially the uSVC was bound to 127.0.0.1 which worked for local tests. But:
   * Not having it listen to all interfaces would make it fail whenever setting it up as a pod/container.
   * Also, it wouldn't allow IPv6 binding.
 - Consequently bind address has been changed to [::]:8000 and if it fails due to lack of support for IPv6, it falls back to
   0.0.0.0:8000
 - Added support for `EAFNOSUPPORT` which is returned by `socket` [1] whenever
   IPv6 is not supported in the environment.
 - The log indicating the uSVC is falling back to IPv4 now uses `log::warn` [2] for
   consistency with actix logs.
 - Added necessary `log` dependency v0.4.27 [3].

Issue: #7

[1]: https://man7.org/linux/man-pages/man2/socket.2.html
[2]: https://docs.rs/log/0.4.27/log/macro.warn.html
[3]: https://docs.rs/log/0.4.27/log/